### PR TITLE
Dynamically populate sitemap with all navigation links

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -3,12 +3,81 @@ import { MetadataRoute } from 'next';
 
 export const dynamic = 'force-static';
 
+const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://firebootcamp.com';
+
+/**
+ * Collects all internal hrefs from global settings (nav, mega menu, footer links).
+ * Normalises them to full URLs and deduplicates.
+ */
+function collectGlobalLinks(global: Record<string, unknown>): string[] {
+  const hrefs: string[] = [];
+  const g = global as {
+    header?: {
+      nav?: { href?: string }[];
+      megaMenu?: { href?: string }[];
+      ctaLink?: string;
+      megaMenuBannerLinkUrl?: string;
+    };
+    footer?: {
+      primaryCtaLink?: string;
+      secondaryCtaLink?: string;
+      linkColumns?: { links?: { href?: string }[] }[];
+    };
+  };
+
+  // Header nav links
+  for (const item of g.header?.nav ?? []) {
+    if (item?.href) hrefs.push(item.href);
+  }
+
+  // Mega menu links
+  for (const item of g.header?.megaMenu ?? []) {
+    if (item?.href) hrefs.push(item.href);
+  }
+
+  // Header CTA & banner links
+  if (g.header?.ctaLink) hrefs.push(g.header.ctaLink);
+  if (g.header?.megaMenuBannerLinkUrl) hrefs.push(g.header.megaMenuBannerLinkUrl);
+
+  // Footer CTA links
+  if (g.footer?.primaryCtaLink) hrefs.push(g.footer.primaryCtaLink);
+  if (g.footer?.secondaryCtaLink) hrefs.push(g.footer.secondaryCtaLink);
+
+  // Footer link columns
+  for (const col of g.footer?.linkColumns ?? []) {
+    for (const link of col?.links ?? []) {
+      if (link?.href) hrefs.push(link.href);
+    }
+  }
+
+  // Normalise to full URLs, keeping only internal links
+  const urls = new Set<string>();
+  for (const href of hrefs) {
+    if (href.startsWith('#')) {
+      // Hash links are sections on the home page
+      urls.add(`${baseUrl}/${href}`);
+    } else if (href.startsWith('/')) {
+      // Internal path links
+      urls.add(`${baseUrl}${href}`);
+    }
+    // Skip external URLs (http/https), mailto:, tel:, etc.
+  }
+
+  return [...urls];
+}
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = 'https://firebootcamp.com';
+  const seenUrls = new Set<string>();
   const entries: MetadataRoute.Sitemap = [];
 
+  const addEntry = (entry: MetadataRoute.Sitemap[number]) => {
+    if (seenUrls.has(entry.url)) return;
+    seenUrls.add(entry.url);
+    entries.push(entry);
+  };
+
   // Home page
-  entries.push({
+  addEntry({
     url: baseUrl,
     lastModified: new Date(),
     changeFrequency: 'daily',
@@ -16,14 +85,29 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   });
 
   // Posts index page
-  entries.push({
+  addEntry({
     url: `${baseUrl}/posts`,
     lastModified: new Date(),
     changeFrequency: 'daily',
     priority: 0.9,
   });
 
-  // Fetch all pages
+  // --- Global settings links (nav, mega menu, footer) ---
+  const globalResponse = await client.queries.global({ relativePath: 'index.json' });
+  const globalData = globalResponse.data?.global;
+
+  if (globalData) {
+    for (const url of collectGlobalLinks(globalData as Record<string, unknown>)) {
+      addEntry({
+        url,
+        lastModified: new Date(),
+        changeFrequency: 'monthly',
+        priority: 0.8,
+      });
+    }
+  }
+
+  // --- TinaCMS pages ---
   let pages = await client.queries.pageConnection();
   const allPages = pages;
 
@@ -36,7 +120,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }
   }
 
-  // Add pages to sitemap
   for (const edge of allPages.data.pageConnection.edges || []) {
     const breadcrumbs = edge?.node?._sys?.breadcrumbs;
     if (!breadcrumbs || (breadcrumbs.length === 1 && breadcrumbs[0] === 'home')) {
@@ -45,7 +128,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     if (!edge?.node) {
       continue;
     }
-    entries.push({
+    addEntry({
       url: `${baseUrl}/${breadcrumbs.join('/')}`,
       lastModified: new Date(),
       changeFrequency: 'monthly',
@@ -53,7 +136,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     });
   }
 
-  // Fetch all posts
+  // --- TinaCMS posts ---
   let posts = await client.queries.postConnection();
   const allPosts = posts;
 
@@ -66,12 +149,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }
   }
 
-  // Add posts to sitemap
   for (const edge of allPosts.data.postConnection.edges || []) {
     const breadcrumbs = edge?.node?._sys?.breadcrumbs;
     if (!breadcrumbs || !edge?.node) continue;
 
-    entries.push({
+    addEntry({
       url: `${baseUrl}/posts/${breadcrumbs.join('/')}`,
       lastModified: edge.node.date ? new Date(edge.node.date) : new Date(),
       changeFrequency: 'weekly',


### PR DESCRIPTION
## Summary
- Sitemap now dynamically pulls all internal links from TinaCMS global settings (header nav, mega menu, CTA links, footer link columns)
- Uses `NEXT_PUBLIC_SITE_URL` env var instead of hardcoded base URL
- Deduplicates all entries so no URL appears twice in the sitemap
- Filters out external links (mailto, tel, other domains) — only internal/hash links included

## Test plan
- [ ] Verify `/sitemap.xml` renders with all nav links (e.g. `/#program`, `/#pricing`, etc.)
- [ ] Verify TinaCMS pages and posts still appear in the sitemap
- [ ] Verify no duplicate URLs in the output
- [ ] Verify external links (mailto, tel, other domains) are excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)