### PR TITLE
fix: stop exposing plain-text emails in mailto links and footer

### DIFF
--- a/components/blocks/fbc-certification.tsx
+++ b/components/blocks/fbc-certification.tsx
@@ -3,17 +3,22 @@ import Image from 'next/image';
 import type { Template } from 'tinacms';
 import { tinaField } from 'tinacms/dist/react';
 import type { PageBlocksFbcCertification } from '../../tina/__generated__/types';
+import { useMailto } from '@/lib/use-mailto';
 import { useLayout } from '../layout/layout-context';
 import { Button } from '../ui/button';
 
 export const FbcCertification = ({ data }: { data: PageBlocksFbcCertification }) => {
   const { globalSettings } = useLayout();
-  const contactEmail = globalSettings?.contactEmail || 'pennywalker@ssw.com.au';
-  const contactCc = globalSettings?.contactCc || 'adamcogan@ssw.com.au';
+  const contactEmail = globalSettings?.contactEmail || 'reklawynnep|ua.moc.wss';
+  const contactCc = globalSettings?.contactCc || 'nagocmada|ua.moc.wss';
   const siteUrl = globalSettings?.siteUrl || 'https://firebootcamp.com.au';
   const subject = data.emailSubject || 'FireBootCamp \u2013 Let\u2019s Talk';
   const body = data.emailBody || `I'm ready to commit to FireBootCamp and earn my certification!\n\n${siteUrl}`;
-  const mailtoLink = `mailto:${contactEmail}?subject=${encodeURIComponent(subject)}&cc=${encodeURIComponent(contactCc)}&body=${encodeURIComponent(body.includes(siteUrl) ? body : `${body}\n\n${siteUrl}`)}`;
+  const mailtoLink = useMailto(contactEmail, {
+    subject,
+    cc: contactCc,
+    body: body.includes(siteUrl) ? body : `${body}\n\n${siteUrl}`,
+  });
 
   return (
     <section className='bg-scheme-1-background px-6 md:px-16 lg:px-16 pt-16 md:pt-24 lg:pt-16 pb-16 md:pb-24 lg:pb-32'>
@@ -56,7 +61,7 @@ export const FbcCertification = ({ data }: { data: PageBlocksFbcCertification })
                   className='w-full sm:w-full sm:min-w-0 min-h-[52px] px-3 bg-black/5 rounded-md font-sans text-[0.875rem] md:text-[1rem] lg:text-[1.125rem] leading-[1.5] border-0 placeholder:text-black/60'
                 />
                 <Button asChild className='bg-red text-white whitespace-nowrap w-full sm:w-fit sm:shrink-0'>
-                  <a href={mailtoLink}>{data.buttonLabel || 'Commit'}</a>
+                  <a href={mailtoLink || undefined}>{data.buttonLabel || 'Commit'}</a>
                 </Button>
               </div>
               <p

--- a/components/blocks/fbc-cta-banner.tsx
+++ b/components/blocks/fbc-cta-banner.tsx
@@ -3,17 +3,22 @@ import Image from 'next/image';
 import type { Template } from 'tinacms';
 import { tinaField } from 'tinacms/dist/react';
 import type { PageBlocksFbcCtaBanner } from '../../tina/__generated__/types';
+import { useMailto } from '@/lib/use-mailto';
 import { useLayout } from '../layout/layout-context';
 import { Button } from '../ui/button';
 
 export const FbcCtaBanner = ({ data }: { data: PageBlocksFbcCtaBanner }) => {
   const { globalSettings } = useLayout();
-  const contactEmail = globalSettings?.contactEmail || 'pennywalker@ssw.com.au';
-  const contactCc = globalSettings?.contactCc || 'adamcogan@ssw.com.au';
+  const contactEmail = globalSettings?.contactEmail || 'reklawynnep|ua.moc.wss';
+  const contactCc = globalSettings?.contactCc || 'nagocmada|ua.moc.wss';
   const siteUrl = globalSettings?.siteUrl || 'https://firebootcamp.com.au';
   const subject = data.emailSubject || 'FireBootCamp \u2013 Let\u2019s Talk';
   const body = data.emailBody || `I'm interested in FireBootCamp, let's schedule a time to chat!\n\n${siteUrl}`;
-  const mailtoLink = `mailto:${contactEmail}?subject=${encodeURIComponent(subject)}&cc=${encodeURIComponent(contactCc)}&body=${encodeURIComponent(body.includes(siteUrl) ? body : `${body}\n\n${siteUrl}`)}`;
+  const mailtoLink = useMailto(contactEmail, {
+    subject,
+    cc: contactCc,
+    body: body.includes(siteUrl) ? body : `${body}\n\n${siteUrl}`,
+  });
 
   return (
     <section className='bg-scheme-4-background px-6 md:px-16 lg:px-16 py-16 md:py-24 lg:py-32'>
@@ -47,7 +52,7 @@ export const FbcCtaBanner = ({ data }: { data: PageBlocksFbcCtaBanner }) => {
                   className='flex-1 min-h-[51px] px-3 bg-white/10 rounded-md font-sans text-[1rem] md:text-[1.125rem] lg:text-[1.25rem] leading-[1.5] text-scheme-4-text border-0 placeholder:!text-white/80'
                 />
                 <Button asChild variant='tertiary' className='whitespace-nowrap w-full sm:w-fit sm:shrink-0'>
-                  <a href={mailtoLink}>{data.buttonLabel || 'Submit'}</a>
+                  <a href={mailtoLink || undefined}>{data.buttonLabel || 'Submit'}</a>
                 </Button>
               </div>
             </div>

--- a/components/blocks/fbc-pricing.tsx
+++ b/components/blocks/fbc-pricing.tsx
@@ -3,23 +3,15 @@ import Image from 'next/image';
 import type { Template } from 'tinacms';
 import { tinaField } from 'tinacms/dist/react';
 import type { PageBlocksFbcPricing, PageBlocksFbcPricingPlans, PageBlocksFbcPricingPlansFeatures } from '../../tina/__generated__/types';
+import { useMailto } from '@/lib/use-mailto';
 import { useLayout } from '../layout/layout-context';
 import { Button } from '../ui/button';
 
 export const FbcPricing = ({ data }: { data: PageBlocksFbcPricing }) => {
   const { globalSettings } = useLayout();
-  const contactEmail = globalSettings?.contactEmail || 'pennywalker@ssw.com.au';
-  const contactCc = globalSettings?.contactCc || 'adamcogan@ssw.com.au';
+  const contactEmail = globalSettings?.contactEmail || 'reklawynnep|ua.moc.wss';
+  const contactCc = globalSettings?.contactCc || 'nagocmada|ua.moc.wss';
   const siteUrl = globalSettings?.siteUrl || 'https://firebootcamp.com.au';
-
-  const generateMailtoLink = (plan: PageBlocksFbcPricingPlans) => {
-    const planName = plan.name || 'Pricing Plan';
-    const subject = (plan as PageBlocksFbcPricingPlans & { emailSubject?: string | null }).emailSubject || `FireBootCamp \u2013 ${planName}`;
-    const emailBody = plan.emailBody ? plan.emailBody.replace('[Plan Name]', planName) : `Hi, I am interested in ${planName}.`;
-    const bodyWithUrl = emailBody.includes(siteUrl) ? emailBody : `${emailBody}\n\n${siteUrl}`;
-
-    return `mailto:${contactEmail}?subject=${encodeURIComponent(subject)}&cc=${encodeURIComponent(contactCc)}&body=${encodeURIComponent(bodyWithUrl)}`;
-  };
 
   return (
     <section id='pricing' className='bg-scheme-3-background px-6 md:px-16 lg:px-16 py-16 md:py-24 lg:py-32 h-fit'>
@@ -56,7 +48,7 @@ export const FbcPricing = ({ data }: { data: PageBlocksFbcPricing }) => {
                   } as React.CSSProperties
                 }
               >
-                <PricingCard plan={plan!} generateMailtoLink={generateMailtoLink} />
+                <PricingCard plan={plan!} contactEmail={contactEmail} contactCc={contactCc} siteUrl={siteUrl} />
               </div>
             );
           })}
@@ -66,11 +58,25 @@ export const FbcPricing = ({ data }: { data: PageBlocksFbcPricing }) => {
   );
 };
 
-const PricingCard = ({ plan, generateMailtoLink }: { plan: PageBlocksFbcPricingPlans; generateMailtoLink: (plan: PageBlocksFbcPricingPlans) => string }) => {
-  const mailtoLink = generateMailtoLink(plan);
+const PricingCard = ({
+  plan,
+  contactEmail,
+  contactCc,
+  siteUrl,
+}: {
+  plan: PageBlocksFbcPricingPlans;
+  contactEmail: string;
+  contactCc: string;
+  siteUrl: string;
+}) => {
   const isFeatured = plan.isFeatured || false;
   const planName = plan.name || 'Pricing Plan';
   const isFullCourse = planName.toLowerCase().includes('full course');
+
+  const subject = (plan as PageBlocksFbcPricingPlans & { emailSubject?: string | null }).emailSubject || `FireBootCamp – ${planName}`;
+  const emailBody = plan.emailBody ? plan.emailBody.replace('[Plan Name]', planName) : `Hi, I am interested in ${planName}.`;
+  const bodyWithUrl = emailBody.includes(siteUrl) ? emailBody : `${emailBody}\n\n${siteUrl}`;
+  const mailtoLink = useMailto(contactEmail, { subject, cc: contactCc, body: bodyWithUrl });
 
   // Parse price for Full Course Access (show $9,000 with $12,000 strikethrough)
   const getPriceDisplay = () => {
@@ -184,7 +190,7 @@ const PricingCard = ({ plan, generateMailtoLink }: { plan: PageBlocksFbcPricingP
 
       <div className={isFeatured ? 'px-6 md:px-8' : 'h-20'}>
         <Button asChild className='w-full bg-red text-white mt-6 md:mt-8'>
-          <a href={mailtoLink}>{plan.ctaLabel || 'Apply now'}</a>
+          <a href={mailtoLink || undefined}>{plan.ctaLabel || 'Apply now'}</a>
         </Button>
       </div>
     </div>

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -1,4 +1,5 @@
 import React, { PropsWithChildren } from 'react';
+import { encodeContact } from '@/lib/contact-encoding';
 import client from '../../tina/__generated__/client';
 import { LayoutProvider } from './layout-context';
 import { Footer } from './nav/footer';
@@ -22,8 +23,16 @@ export default async function Layout({ children, rawPageData }: LayoutProps) {
     }
   );
 
+  // Encode contact email/cc so the address never appears verbatim in the SSR
+  // HTML / RSC payload (anti-harvesting). useMailto decodes on the client.
+  const safeGlobal = {
+    ...globalData.global,
+    contactEmail: globalData.global.contactEmail ? encodeContact(globalData.global.contactEmail) : globalData.global.contactEmail,
+    contactCc: globalData.global.contactCc ? encodeContact(globalData.global.contactCc) : globalData.global.contactCc,
+  };
+
   return (
-    <LayoutProvider globalSettings={globalData.global} pageData={rawPageData || {}}>
+    <LayoutProvider globalSettings={safeGlobal} pageData={rawPageData || {}}>
       <Header />
       <main id='main-content' className='overflow-x-hidden'>
         {children}

--- a/components/layout/nav/footer.tsx
+++ b/components/layout/nav/footer.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { Button } from '@/components/ui/button';
 import { AutoLink } from '@/components/ui/link';
+import { useMailto } from '@/lib/use-mailto';
 import Link from 'next/link';
 import React from 'react';
 import { useLayout } from '../layout-context';
@@ -9,11 +10,14 @@ export const Footer = () => {
   const { globalSettings } = useLayout();
   const { header, footer } = globalSettings || {};
 
-  const contactEmail = globalSettings?.contactEmail || 'pennywalker@ssw.com.au';
-  const contactCc = globalSettings?.contactCc || 'adamcogan@ssw.com.au';
+  const contactEmail = globalSettings?.contactEmail || 'reklawynnep|ua.moc.wss';
+  const contactCc = globalSettings?.contactCc || 'nagocmada|ua.moc.wss';
   const siteUrl = globalSettings?.siteUrl || 'https://firebootcamp.com.au';
-  const mailtoLink = `mailto:${contactEmail}?subject=${encodeURIComponent('FireBootCamp \u2013 Let\u2019s Talk')}&cc=${encodeURIComponent(contactCc)}&body=${encodeURIComponent(`I'm interested in FireBootCamp, let's schedule a time to chat!\n\n${siteUrl}`)}`;
-  const contactEmailLink = `mailto:${contactEmail}?subject=${encodeURIComponent('FireBootCamp \u2013 Let\u2019s Talk')}&cc=${encodeURIComponent(contactCc)}&body=${encodeURIComponent(`I'm interested in FireBootCamp, let's schedule a time to chat!\n\n${siteUrl}`)}`;
+  const mailtoLink = useMailto(contactEmail, {
+    subject: 'FireBootCamp \u2013 Let\u2019s Talk',
+    cc: contactCc,
+    body: `I'm interested in FireBootCamp, let's schedule a time to chat!\n\n${siteUrl}`,
+  });
 
   return (
     <footer className='bg-scheme-2-background px-6 md:px-16 lg:px-16 py-10 md:py-16 lg:py-20'>
@@ -31,7 +35,7 @@ export const Footer = () => {
 
             <div className='flex flex-col sm:flex-row gap-3 md:gap-4 w-full'>
               <Button asChild className='bg-red text-white w-full sm:w-fit sm:shrink-0'>
-                <a href={mailtoLink}>{footer?.primaryCtaLabel || 'Apply now'}</a>
+                <a href={mailtoLink || undefined}>{footer?.primaryCtaLabel || 'Apply now'}</a>
               </Button>
               <Button asChild variant='secondaryAlternate' className='w-full sm:w-fit sm:shrink-0 normal-case'>
                 <AutoLink href={footer?.secondaryCtaLink || '#'}>{footer?.secondaryCtaLabel || 'Go to SSW events'}</AutoLink>
@@ -64,7 +68,7 @@ export const Footer = () => {
                   ) : (
                     <AutoLink
                       key={linkIndex}
-                      href={link?.href?.startsWith(`mailto:${contactEmail}`) ? contactEmailLink : (link?.href || '#')}
+                      href={link?.href || '#'}
                       className={`py-1 md:py-2 text-scheme-2-text hover:text-scheme-2-text/80 font-sans text-[0.875rem] md:text-[1rem] lg:text-[1.125rem] leading-[1.5] ${link?.isHeading ? 'font-semibold' : ''}`}
                     >
                       {link?.label}

--- a/components/layout/nav/header.tsx
+++ b/components/layout/nav/header.tsx
@@ -12,10 +12,6 @@ export const Header = () => {
   const header = globalSettings?.header;
   const megaMenu = globalSettings?.header?.megaMenu;
 
-  const contactEmail = globalSettings?.contactEmail || 'pennywalker@ssw.com.au';
-  const contactSubject = globalSettings?.contactSubject || "SSW Firebootcamp - Let's chat";
-  const mailtoLink = `mailto:${contactEmail}?subject=${encodeURIComponent(contactSubject)}`;
-
   const [menuState, setMenuState] = React.useState(false);
   const [megaMenuOpen, setMegaMenuOpen] = React.useState(false);
 

--- a/content/global/index.json
+++ b/content/global/index.json
@@ -60,14 +60,6 @@
             "label": "FAQs",
             "href": "#faqs",
             "isHeading": true
-          },
-          {
-            "label": "pennywalker@ssw.com.au",
-            "href": "mailto:pennywalker@ssw.com.au"
-          },
-          {
-            "label": "+61 2 9953 3000",
-            "href": "tel:+61299533000"
           }
         ]
       }

--- a/lib/contact-encoding.ts
+++ b/lib/contact-encoding.ts
@@ -1,0 +1,13 @@
+const SEPARATOR = '|';
+
+export const encodeContact = (email: string) => {
+  if (!email || !email.includes('@')) return email;
+  const [local, domain] = email.split('@');
+  return `${[...local].reverse().join('')}${SEPARATOR}${[...domain].reverse().join('')}`;
+};
+
+export const decodeContact = (encoded: string) => {
+  if (!encoded || !encoded.includes(SEPARATOR)) return encoded;
+  const [local, domain] = encoded.split(SEPARATOR);
+  return `${[...local].reverse().join('')}@${[...domain].reverse().join('')}`;
+};

--- a/lib/use-mailto.ts
+++ b/lib/use-mailto.ts
@@ -1,0 +1,31 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { decodeContact } from './contact-encoding';
+
+type MailtoOptions = {
+  subject?: string;
+  cc?: string;
+  body?: string;
+};
+
+export const useMailto = (encodedEmail: string, options?: MailtoOptions) => {
+  const [href, setHref] = useState('');
+  const subject = options?.subject;
+  const encodedCc = options?.cc;
+  const body = options?.body;
+
+  useEffect(() => {
+    const email = decodeContact(encodedEmail);
+    const cc = encodedCc ? decodeContact(encodedCc) : undefined;
+    const params = [
+      subject ? `subject=${encodeURIComponent(subject)}` : '',
+      cc ? `cc=${encodeURIComponent(cc)}` : '',
+      body ? `body=${encodeURIComponent(body)}` : '',
+    ]
+      .filter(Boolean)
+      .join('&');
+    setHref(`mailto:${email}${params ? `?${params}` : ''}`);
+  }, [encodedEmail, subject, encodedCc, body]);
+
+  return href;
+};


### PR DESCRIPTION
Closes #106

## Summary
- Contact email (`pennywalker@ssw.com.au`) and CC (`adamcogan@ssw.com.au`) were embedded verbatim in every `mailto:` href and in the RSC payload via `globalSettings`, so scrapers reading the SSR HTML harvested them directly. The footer also rendered the email and phone number as plain-text link rows.
- Encode `contactEmail` / `contactCc` at the server boundary in `components/layout/layout.tsx` so the address never appears in the response HTML. New `useMailto` client hook decodes after hydration and assembles the `mailto:` URL only then; CTA anchors render hrefless during SSR.
- Remove the visible email + phone-number rows from the footer link column in `content/global/index.json`.
- Drop dead `mailtoLink` constant in `header.tsx` (was computed but never used).

## What changed
- `lib/contact-encoding.ts` (new) — split-and-reverse encoder/decoder; `pennywalker@ssw.com.au` ↔ `reklawynnep|ua.moc.wss`. Keeps the value out of regex-based scrapers without touching the Tina schema or editor flow (editors still type a normal email; encoding happens at render time).
- `lib/use-mailto.ts` (new) — client hook returning `""` during SSR, real `mailto:` URL after `useEffect` runs.
- `components/layout/layout.tsx` — encodes `contactEmail` / `contactCc` before passing `globalSettings` to `LayoutProvider`.
- `components/blocks/fbc-cta-banner.tsx`, `fbc-certification.tsx`, `fbc-pricing.tsx`, `components/layout/nav/footer.tsx` — swapped inline `mailto:` template literals for `useMailto(...)`; `<a href={mailtoLink || undefined}>` so SSR emits no href; pre-encoded fallback constants.
- `components/layout/nav/header.tsx` — removed dead mailto code.
- `content/global/index.json` — deleted the `pennywalker@ssw.com.au` and `+61 2 9953 3000` link entries from the footer column. Heading rows untouched. Tina `contactEmail` / `contactCc` fields kept as plain strings so editors can still change the address.

## Test plan
- [x] `curl -s http://localhost:3000/` — `pennywalker`, `adamcogan`, `mailto:`, `@ssw.com.au`, and `9953` all return 0 hits.
- [x] Encoded values (`reklawynnep|ua.moc.wss`, `nagocmada|ua.moc.wss`) appear in the React state blob and decode back to the correct addresses (verified standalone).
- [x] CTA buttons render with no `href` in the SSR HTML.
- [ ] Reviewer: load the page, confirm CTA buttons (header Apply now, CTA-banner Submit, certification Commit, every pricing-card CTA, footer Apply now) open the system mail client with the correct `to`, `cc`, `subject`, and `body` after hydration.
- [ ] Reviewer: confirm footer no longer shows the email or phone-number text rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)