### PR TITLE
fix: obfuscate mailto email addresses to prevent scraping (#106)

### DIFF
--- a/components/blocks/fbc-certification.tsx
+++ b/components/blocks/fbc-certification.tsx
@@ -5,15 +5,14 @@ import { tinaField } from 'tinacms/dist/react';
 import type { PageBlocksFbcCertification } from '../../tina/__generated__/types';
 import { useLayout } from '../layout/layout-context';
 import { Button } from '../ui/button';
+import { MailtoLink } from '../ui/mailto-link';
 
 export const FbcCertification = ({ data }: { data: PageBlocksFbcCertification }) => {
-  const { globalSettings } = useLayout();
-  const contactEmail = globalSettings?.contactEmail || 'pennywalker@ssw.com.au';
-  const contactCc = globalSettings?.contactCc || 'adamcogan@ssw.com.au';
+  const { globalSettings, encodedContactEmail, encodedContactCc } = useLayout();
   const siteUrl = globalSettings?.siteUrl || 'https://firebootcamp.com.au';
   const subject = data.emailSubject || 'FireBootCamp \u2013 Let\u2019s Talk';
-  const body = data.emailBody || `I'm ready to commit to FireBootCamp and earn my certification!\n\n${siteUrl}`;
-  const mailtoLink = `mailto:${contactEmail}?subject=${encodeURIComponent(subject)}&cc=${encodeURIComponent(contactCc)}&body=${encodeURIComponent(body.includes(siteUrl) ? body : `${body}\n\n${siteUrl}`)}`;
+  const rawBody = data.emailBody || `I'm ready to commit to FireBootCamp and earn my certification!`;
+  const body = rawBody.includes(siteUrl) ? rawBody : `${rawBody}\n\n${siteUrl}`;
 
   return (
     <section className='bg-scheme-1-background px-6 md:px-16 lg:px-16 pt-16 md:pt-24 lg:pt-16 pb-16 md:pb-24 lg:pb-32'>
@@ -56,7 +55,9 @@ export const FbcCertification = ({ data }: { data: PageBlocksFbcCertification })
                   className='w-full sm:w-full sm:min-w-0 min-h-[52px] px-3 bg-black/5 rounded-md font-sans text-[0.875rem] md:text-[1rem] lg:text-[1.125rem] leading-[1.5] border-0 placeholder:text-black/60'
                 />
                 <Button asChild className='bg-red text-white whitespace-nowrap w-full sm:w-fit sm:shrink-0'>
-                  <a href={mailtoLink}>{data.buttonLabel || 'Commit'}</a>
+                  <MailtoLink encodedEmail={encodedContactEmail} encodedCc={encodedContactCc} subject={subject} body={body}>
+                    {data.buttonLabel || 'Commit'}
+                  </MailtoLink>
                 </Button>
               </div>
               <p

--- a/components/blocks/fbc-cta-banner.tsx
+++ b/components/blocks/fbc-cta-banner.tsx
@@ -5,15 +5,14 @@ import { tinaField } from 'tinacms/dist/react';
 import type { PageBlocksFbcCtaBanner } from '../../tina/__generated__/types';
 import { useLayout } from '../layout/layout-context';
 import { Button } from '../ui/button';
+import { MailtoLink } from '../ui/mailto-link';
 
 export const FbcCtaBanner = ({ data }: { data: PageBlocksFbcCtaBanner }) => {
-  const { globalSettings } = useLayout();
-  const contactEmail = globalSettings?.contactEmail || 'pennywalker@ssw.com.au';
-  const contactCc = globalSettings?.contactCc || 'adamcogan@ssw.com.au';
+  const { globalSettings, encodedContactEmail, encodedContactCc } = useLayout();
   const siteUrl = globalSettings?.siteUrl || 'https://firebootcamp.com.au';
   const subject = data.emailSubject || 'FireBootCamp \u2013 Let\u2019s Talk';
-  const body = data.emailBody || `I'm interested in FireBootCamp, let's schedule a time to chat!\n\n${siteUrl}`;
-  const mailtoLink = `mailto:${contactEmail}?subject=${encodeURIComponent(subject)}&cc=${encodeURIComponent(contactCc)}&body=${encodeURIComponent(body.includes(siteUrl) ? body : `${body}\n\n${siteUrl}`)}`;
+  const rawBody = data.emailBody || `I'm interested in FireBootCamp, let's schedule a time to chat!`;
+  const body = rawBody.includes(siteUrl) ? rawBody : `${rawBody}\n\n${siteUrl}`;
 
   return (
     <section className='bg-scheme-4-background px-6 md:px-16 lg:px-16 py-16 md:py-24 lg:py-32'>
@@ -47,7 +46,9 @@ export const FbcCtaBanner = ({ data }: { data: PageBlocksFbcCtaBanner }) => {
                   className='flex-1 min-h-[51px] px-3 bg-white/10 rounded-md font-sans text-[1rem] md:text-[1.125rem] lg:text-[1.25rem] leading-[1.5] text-scheme-4-text border-0 placeholder:!text-white/80'
                 />
                 <Button asChild variant='tertiary' className='whitespace-nowrap w-full sm:w-fit sm:shrink-0'>
-                  <a href={mailtoLink}>{data.buttonLabel || 'Submit'}</a>
+                  <MailtoLink encodedEmail={encodedContactEmail} encodedCc={encodedContactCc} subject={subject} body={body}>
+                    {data.buttonLabel || 'Submit'}
+                  </MailtoLink>
                 </Button>
               </div>
             </div>

--- a/components/blocks/fbc-pricing.tsx
+++ b/components/blocks/fbc-pricing.tsx
@@ -5,20 +5,20 @@ import { tinaField } from 'tinacms/dist/react';
 import type { PageBlocksFbcPricing, PageBlocksFbcPricingPlans, PageBlocksFbcPricingPlansFeatures } from '../../tina/__generated__/types';
 import { useLayout } from '../layout/layout-context';
 import { Button } from '../ui/button';
+import { MailtoLink } from '../ui/mailto-link';
+
+type PlanMailto = { subject: string; body: string };
 
 export const FbcPricing = ({ data }: { data: PageBlocksFbcPricing }) => {
   const { globalSettings } = useLayout();
-  const contactEmail = globalSettings?.contactEmail || 'pennywalker@ssw.com.au';
-  const contactCc = globalSettings?.contactCc || 'adamcogan@ssw.com.au';
   const siteUrl = globalSettings?.siteUrl || 'https://firebootcamp.com.au';
 
-  const generateMailtoLink = (plan: PageBlocksFbcPricingPlans) => {
+  const buildPlanMailto = (plan: PageBlocksFbcPricingPlans): PlanMailto => {
     const planName = plan.name || 'Pricing Plan';
     const subject = (plan as PageBlocksFbcPricingPlans & { emailSubject?: string | null }).emailSubject || `FireBootCamp \u2013 ${planName}`;
     const emailBody = plan.emailBody ? plan.emailBody.replace('[Plan Name]', planName) : `Hi, I am interested in ${planName}.`;
-    const bodyWithUrl = emailBody.includes(siteUrl) ? emailBody : `${emailBody}\n\n${siteUrl}`;
-
-    return `mailto:${contactEmail}?subject=${encodeURIComponent(subject)}&cc=${encodeURIComponent(contactCc)}&body=${encodeURIComponent(bodyWithUrl)}`;
+    const body = emailBody.includes(siteUrl) ? emailBody : `${emailBody}\n\n${siteUrl}`;
+    return { subject, body };
   };
 
   return (
@@ -56,7 +56,7 @@ export const FbcPricing = ({ data }: { data: PageBlocksFbcPricing }) => {
                   } as React.CSSProperties
                 }
               >
-                <PricingCard plan={plan!} generateMailtoLink={generateMailtoLink} />
+                <PricingCard plan={plan!} mailto={buildPlanMailto(plan!)} />
               </div>
             );
           })}
@@ -66,8 +66,8 @@ export const FbcPricing = ({ data }: { data: PageBlocksFbcPricing }) => {
   );
 };
 
-const PricingCard = ({ plan, generateMailtoLink }: { plan: PageBlocksFbcPricingPlans; generateMailtoLink: (plan: PageBlocksFbcPricingPlans) => string }) => {
-  const mailtoLink = generateMailtoLink(plan);
+const PricingCard = ({ plan, mailto }: { plan: PageBlocksFbcPricingPlans; mailto: PlanMailto }) => {
+  const { encodedContactEmail, encodedContactCc } = useLayout();
   const isFeatured = plan.isFeatured || false;
   const planName = plan.name || 'Pricing Plan';
   const isFullCourse = planName.toLowerCase().includes('full course');
@@ -184,7 +184,9 @@ const PricingCard = ({ plan, generateMailtoLink }: { plan: PageBlocksFbcPricingP
 
       <div className={isFeatured ? 'px-6 md:px-8' : 'h-20'}>
         <Button asChild className='w-full bg-red text-white mt-6 md:mt-8'>
-          <a href={mailtoLink}>{plan.ctaLabel || 'Apply now'}</a>
+          <MailtoLink encodedEmail={encodedContactEmail} encodedCc={encodedContactCc} subject={mailto.subject} body={mailto.body}>
+            {plan.ctaLabel || 'Apply now'}
+          </MailtoLink>
         </Button>
       </div>
     </div>

--- a/components/layout/layout-context.tsx
+++ b/components/layout/layout-context.tsx
@@ -8,6 +8,8 @@ interface LayoutState {
   pageData: {};
   setPageData: React.Dispatch<React.SetStateAction<{}>>;
   theme: GlobalQuery['global']['theme'];
+  encodedContactEmail: string;
+  encodedContactCc: string;
 }
 
 const LayoutContext = React.createContext<LayoutState | undefined>(undefined);
@@ -22,6 +24,8 @@ export const useLayout = () => {
       },
       globalSettings: undefined,
       pageData: undefined,
+      encodedContactEmail: '',
+      encodedContactCc: '',
     }
   );
 };
@@ -30,9 +34,17 @@ interface LayoutProviderProps {
   children: React.ReactNode;
   globalSettings: GlobalQuery['global'];
   pageData: {};
+  encodedContactEmail: string;
+  encodedContactCc: string;
 }
 
-export const LayoutProvider: React.FC<LayoutProviderProps> = ({ children, globalSettings: initialGlobalSettings, pageData: initialPageData }) => {
+export const LayoutProvider: React.FC<LayoutProviderProps> = ({
+  children,
+  globalSettings: initialGlobalSettings,
+  pageData: initialPageData,
+  encodedContactEmail,
+  encodedContactCc,
+}) => {
   const [globalSettings, setGlobalSettings] = useState<GlobalQuery['global']>(initialGlobalSettings);
   const [pageData, setPageData] = useState<{}>(initialPageData);
 
@@ -46,6 +58,8 @@ export const LayoutProvider: React.FC<LayoutProviderProps> = ({ children, global
         pageData,
         setPageData,
         theme,
+        encodedContactEmail,
+        encodedContactCc,
       }}
     >
       {children}

--- a/components/layout/layout.tsx
+++ b/components/layout/layout.tsx
@@ -1,5 +1,6 @@
 import React, { PropsWithChildren } from 'react';
 import client from '../../tina/__generated__/client';
+import { encodeBase64 } from '../../lib/email-obfuscation';
 import { LayoutProvider } from './layout-context';
 import { Footer } from './nav/footer';
 import { Header } from './nav/header';
@@ -7,6 +8,9 @@ import { Header } from './nav/header';
 type LayoutProps = PropsWithChildren & {
   rawPageData?: Record<string, unknown> | null;
 };
+
+const FALLBACK_CONTACT_EMAIL = 'pennywalker@ssw.com.au';
+const FALLBACK_CONTACT_CC = 'adamcogan@ssw.com.au';
 
 export default async function Layout({ children, rawPageData }: LayoutProps) {
   const { data: globalData } = await client.queries.global(
@@ -22,8 +26,26 @@ export default async function Layout({ children, rawPageData }: LayoutProps) {
     }
   );
 
+  // Strip plaintext email fields before they cross to the client and pass
+  // base64-encoded copies instead. The client decodes only at runtime,
+  // keeping addresses out of SSR HTML and the hydration payload.
+  const rawEmail = globalData.global.contactEmail || FALLBACK_CONTACT_EMAIL;
+  const rawCc = globalData.global.contactCc || FALLBACK_CONTACT_CC;
+  const sanitizedGlobal = {
+    ...globalData.global,
+    contactEmail: null,
+    contactCc: null,
+  };
+  const encodedContactEmail = encodeBase64(rawEmail);
+  const encodedContactCc = encodeBase64(rawCc);
+
   return (
-    <LayoutProvider globalSettings={globalData.global} pageData={rawPageData || {}}>
+    <LayoutProvider
+      globalSettings={sanitizedGlobal}
+      pageData={rawPageData || {}}
+      encodedContactEmail={encodedContactEmail}
+      encodedContactCc={encodedContactCc}
+    >
       <Header />
       <main id='main-content' className='overflow-x-hidden'>
         {children}

--- a/components/layout/nav/footer.tsx
+++ b/components/layout/nav/footer.tsx
@@ -1,19 +1,18 @@
 'use client';
 import { Button } from '@/components/ui/button';
 import { AutoLink } from '@/components/ui/link';
+import { MailtoLink } from '@/components/ui/mailto-link';
 import Link from 'next/link';
 import React from 'react';
 import { useLayout } from '../layout-context';
 
 export const Footer = () => {
-  const { globalSettings } = useLayout();
+  const { globalSettings, encodedContactEmail, encodedContactCc } = useLayout();
   const { header, footer } = globalSettings || {};
 
-  const contactEmail = globalSettings?.contactEmail || 'pennywalker@ssw.com.au';
-  const contactCc = globalSettings?.contactCc || 'adamcogan@ssw.com.au';
   const siteUrl = globalSettings?.siteUrl || 'https://firebootcamp.com.au';
-  const mailtoLink = `mailto:${contactEmail}?subject=${encodeURIComponent('FireBootCamp \u2013 Let\u2019s Talk')}&cc=${encodeURIComponent(contactCc)}&body=${encodeURIComponent(`I'm interested in FireBootCamp, let's schedule a time to chat!\n\n${siteUrl}`)}`;
-  const contactEmailLink = `mailto:${contactEmail}?subject=${encodeURIComponent('FireBootCamp \u2013 Let\u2019s Talk')}&cc=${encodeURIComponent(contactCc)}&body=${encodeURIComponent(`I'm interested in FireBootCamp, let's schedule a time to chat!\n\n${siteUrl}`)}`;
+  const ctaSubject = 'FireBootCamp \u2013 Let\u2019s Talk';
+  const ctaBody = `I'm interested in FireBootCamp, let's schedule a time to chat!\n\n${siteUrl}`;
 
   return (
     <footer className='bg-scheme-2-background px-6 md:px-16 lg:px-16 py-10 md:py-16 lg:py-20'>
@@ -31,7 +30,9 @@ export const Footer = () => {
 
             <div className='flex flex-col sm:flex-row gap-3 md:gap-4 w-full'>
               <Button asChild className='bg-red text-white w-full sm:w-fit sm:shrink-0'>
-                <a href={mailtoLink}>{footer?.primaryCtaLabel || 'Apply now'}</a>
+                <MailtoLink encodedEmail={encodedContactEmail} encodedCc={encodedContactCc} subject={ctaSubject} body={ctaBody}>
+                  {footer?.primaryCtaLabel || 'Apply now'}
+                </MailtoLink>
               </Button>
               <Button asChild variant='secondaryAlternate' className='w-full sm:w-fit sm:shrink-0 normal-case'>
                 <AutoLink href={footer?.secondaryCtaLink || '#'}>{footer?.secondaryCtaLabel || 'Go to SSW events'}</AutoLink>
@@ -64,7 +65,7 @@ export const Footer = () => {
                   ) : (
                     <AutoLink
                       key={linkIndex}
-                      href={link?.href?.startsWith(`mailto:${contactEmail}`) ? contactEmailLink : (link?.href || '#')}
+                      href={link?.href || '#'}
                       className={`py-1 md:py-2 text-scheme-2-text hover:text-scheme-2-text/80 font-sans text-[0.875rem] md:text-[1rem] lg:text-[1.125rem] leading-[1.5] ${link?.isHeading ? 'font-semibold' : ''}`}
                     >
                       {link?.label}

--- a/components/layout/nav/header.tsx
+++ b/components/layout/nav/header.tsx
@@ -12,10 +12,6 @@ export const Header = () => {
   const header = globalSettings?.header;
   const megaMenu = globalSettings?.header?.megaMenu;
 
-  const contactEmail = globalSettings?.contactEmail || 'pennywalker@ssw.com.au';
-  const contactSubject = globalSettings?.contactSubject || "SSW Firebootcamp - Let's chat";
-  const mailtoLink = `mailto:${contactEmail}?subject=${encodeURIComponent(contactSubject)}`;
-
   const [menuState, setMenuState] = React.useState(false);
   const [megaMenuOpen, setMegaMenuOpen] = React.useState(false);
 

--- a/components/ui/mailto-link.tsx
+++ b/components/ui/mailto-link.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import React, { useEffect, useRef } from 'react';
+import { buildMailtoHref, decodeBase64 } from '@/lib/email-obfuscation';
+
+type MailtoLinkProps = {
+  encodedEmail: string;
+  encodedCc?: string;
+  subject?: string;
+  body?: string;
+} & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'>;
+
+export const MailtoLink = React.forwardRef<HTMLAnchorElement, MailtoLinkProps>(function MailtoLink(
+  { encodedEmail, encodedCc, subject, body, children, ...rest },
+  forwardedRef
+) {
+  const innerRef = useRef<HTMLAnchorElement | null>(null);
+
+  useEffect(() => {
+    const node = innerRef.current;
+    if (!node || !encodedEmail) return;
+    const email = decodeBase64(encodedEmail);
+    const cc = encodedCc ? decodeBase64(encodedCc) : undefined;
+    node.href = buildMailtoHref({ email, cc, subject, body });
+  }, [encodedEmail, encodedCc, subject, body]);
+
+  const setRef = (node: HTMLAnchorElement | null) => {
+    innerRef.current = node;
+    if (typeof forwardedRef === 'function') forwardedRef(node);
+    else if (forwardedRef) forwardedRef.current = node;
+  };
+
+  return (
+    <a ref={setRef} href='#contact' rel='nofollow' {...rest}>
+      {children}
+    </a>
+  );
+});

--- a/content/global/index.json
+++ b/content/global/index.json
@@ -60,14 +60,6 @@
             "label": "FAQs",
             "href": "#faqs",
             "isHeading": true
-          },
-          {
-            "label": "pennywalker@ssw.com.au",
-            "href": "mailto:pennywalker@ssw.com.au"
-          },
-          {
-            "label": "+61 2 9953 3000",
-            "href": "tel:+61299533000"
           }
         ]
       }

--- a/lib/email-obfuscation.ts
+++ b/lib/email-obfuscation.ts
@@ -1,0 +1,33 @@
+// Encode/decode helpers for hiding email addresses from page-level scrapers.
+// Encoded values are emitted in the SSR HTML and hydration payload; the real
+// `mailto:` URL is only ever assembled on the client after hydration.
+// See: https://www.ssw.com.au/rules/avoid-using-mailto-on-your-website
+
+export function encodeBase64(value: string): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(value, 'utf8').toString('base64');
+  }
+  return btoa(unescape(encodeURIComponent(value)));
+}
+
+export function decodeBase64(encoded: string): string {
+  if (typeof Buffer !== 'undefined') {
+    return Buffer.from(encoded, 'base64').toString('utf8');
+  }
+  return decodeURIComponent(escape(atob(encoded)));
+}
+
+export type MailtoParts = {
+  email: string;
+  cc?: string;
+  subject?: string;
+  body?: string;
+};
+
+export function buildMailtoHref({ email, cc, subject, body }: MailtoParts): string {
+  const params: string[] = [];
+  if (subject) params.push(`subject=${encodeURIComponent(subject)}`);
+  if (cc) params.push(`cc=${encodeURIComponent(cc)}`);
+  if (body) params.push(`body=${encodeURIComponent(body)}`);
+  return params.length > 0 ? `mailto:${email}?${params.join('&')}` : `mailto:${email}`;
+}


### PR DESCRIPTION
Closes #106.

## Summary

- Encode `contactEmail` / `contactCc` as base64 at the server→client boundary in `components/layout/layout.tsx` and decode them in a new `<MailtoLink />` client component via `useEffect`, so addresses never appear in SSR HTML or the hydration payload.
- Remove the plaintext `pennywalker@ssw.com.au` and `+61 2 9953 3000` link entries from the footer per request — the footer's primary CTA mailto button stays.
- Implements the fallback approach from the SSW rule when a contact form isn't feasible: https://www.ssw.com.au/rules/avoid-using-mailto-on-your-website

## Why

Issue #106 flagged that `mailto:` `href` attributes were exposing plaintext email addresses to scrapers. Acceptance criteria called for the email contact to remain usable while removing the plaintext exposure across all occurrences.

## What changed

**New**
- `lib/email-obfuscation.ts` — isomorphic base64 encode/decode + `buildMailtoHref` helper.
- `components/ui/mailto-link.tsx` — `'use client'` component that renders `<a href="#contact">` server-side and swaps to a real `mailto:` URL via `useEffect` after hydration. Forwards refs so it composes with `<Button asChild>`.

**Modified**
- `components/layout/layout.tsx` — encodes `contactEmail` / `contactCc` once and strips the plaintext fields before they reach `LayoutProvider`.
- `components/layout/layout-context.tsx` — exposes `encodedContactEmail` / `encodedContactCc` via context.
- `components/blocks/fbc-pricing.tsx`, `components/blocks/fbc-certification.tsx`, `components/blocks/fbc-cta-banner.tsx` — swap `<a href={mailtoLink}>…</a>` for `<MailtoLink>` (still wrapped by `<Button asChild>`).
- `components/layout/nav/footer.tsx` — primary CTA now uses `<MailtoLink>`; deleted the dead `link.href.startsWith('mailto:…')` branch and the duplicate `contactEmailLink` constant.
- `components/layout/nav/header.tsx` — removed unused `mailtoLink` dead code.
- `content/global/index.json` — removed `pennywalker@ssw.com.au` and `+61 2 9953 3000` link entries.

Editors keep entering plaintext into the TinaCMS Global → Contact Email field. Encoding is internal.

## Test plan

- [x] `pnpm install`, `pnpm dev`, open http://localhost:3000
- [x] View source: confirm zero matches for `pennywalker`, `adamcogan`, `9953 3000`, and `mailto:`
- [x] Click each CTA (Apply now / Commit / Submit) on Pricing, Certification, CTA Banner, and Footer — verify the email client opens with correct To, CC, Subject, and Body
- [x] Confirm the footer no longer shows the email or phone-number rows
- [x] DevTools → Network → main document: search payload for `pennywalker` / `adamcogan` — zero matches
- [x] In TinaCMS admin (`/admin`), edit Global → Contact Email, save, verify a CTA opens `mailto:` with the new address
- [ ] `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)